### PR TITLE
remove warnings about public configurations

### DIFF
--- a/config.go
+++ b/config.go
@@ -183,15 +183,6 @@ func Load() {
 		panic(err)
 	}
 
-	if !PrestConf.AccessConf.Restrict {
-		log.Warningln("You are running pREST in public mode.")
-	}
-
-	if PrestConf.Debug {
-		log.DebugMode = PrestConf.Debug
-		log.Warningln("You are running pREST in debug mode.")
-	}
-
 	if _, err = os.Stat(PrestConf.QueriesPath); os.IsNotExist(err) {
 		if err = os.MkdirAll(PrestConf.QueriesPath, 0700); os.IsNotExist(err) {
 			log.Errorf("Queries directory %s is not created", PrestConf.QueriesPath)


### PR DESCRIPTION
* remove warning when load with restrict equals false, because it should only happens
when startup the server
* remove warning when load with debug equals true, because it should only happens
when startup the server

related to https://github.com/prest/prest/issues/307