### PR TITLE
from os/user to github.com/mitchellh/go-homedir

### DIFF
--- a/config.go
+++ b/config.go
@@ -101,7 +101,8 @@ func viperCfg() {
 	viper.SetDefault("https.key", "/etc/certs/cert.key")
 	hDir, err := homedir.Dir()
 	if err != nil {
-		log.Errorln(err)
+		log.Fatal(err)
+
 	}
 	viper.SetDefault("queries.location", filepath.Join(hDir, "queries"))
 }

--- a/config.go
+++ b/config.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/nuveo/log"
 	"github.com/prest/adapters"
 	"github.com/spf13/viper"
@@ -99,14 +99,11 @@ func viperCfg() {
 	viper.SetDefault("https.mode", false)
 	viper.SetDefault("https.cert", "/etc/certs/cert.crt")
 	viper.SetDefault("https.key", "/etc/certs/cert.key")
-
-	user, err := user.Current()
+	hDir, err := homedir.Dir()
 	if err != nil {
 		log.Errorln(err)
-		return
 	}
-
-	viper.SetDefault("queries.location", filepath.Join(user.HomeDir, "queries"))
+	viper.SetDefault("queries.location", filepath.Join(hDir, "queries"))
 }
 
 func getDefaultPrestConf(prestConf string) (cfg string) {


### PR DESCRIPTION
Why not just use os/user? The built-in os/user package requires cgo on some operatinal systems. This means that any Go code that uses that package cannot cross compile. But 99% of the time the use for os/user is just to retrieve the home directory, which we can do for the current user without cgo. This library does that, enabling cross-compilation