### PR TITLE
Database url fix

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -142,15 +142,14 @@ func TestGetDefaultPrestConf(t *testing.T) {
 }
 
 func TestDatabaseURL(t *testing.T) {
-	os.Setenv("PREST_CONF", "")
 	os.Setenv("PREST_PG_URL", "postgresql://user:pass@localhost:1234/mydatabase/?sslmode=disable")
+
 	viperCfg()
 	cfg := &Prest{}
 	err := Parse(cfg)
 	if err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-
 	if cfg.PGDatabase != "mydatabase" {
 		t.Errorf("expected database name: mydatabase, got: %s", cfg.PGDatabase)
 	}
@@ -170,7 +169,9 @@ func TestDatabaseURL(t *testing.T) {
 		t.Errorf("expected database ssl mode: disable, got: %s", cfg.SSLMode)
 	}
 
-	os.Setenv("DATABASE_URL", "postgresql://user:pass@localhost:5432/mydatabase/?sslmode=disable")
+	os.Unsetenv("PREST_PG_URL")
+	os.Setenv("DATABASE_URL", "postgresql://cloud:cloudPass@localhost:5432/CloudDatabase/?sslmode=disable")
+
 	cfg = &Prest{}
 	err = Parse(cfg)
 	if err != nil {
@@ -179,6 +180,17 @@ func TestDatabaseURL(t *testing.T) {
 	if cfg.PGPort != 5432 {
 		t.Errorf("expected database port: 5432, got: %d", cfg.PGPort)
 	}
+	if cfg.PGUser != "cloud" {
+		t.Errorf("expected database user: cloud, got: %s", cfg.PGUser)
+	}
+	if cfg.PGPass != "cloudPass" {
+		t.Errorf("expected database password: cloudPass, got: %s", cfg.PGPass)
+	}
+	if cfg.SSLMode != "disable" {
+		t.Errorf("expected database SSL mode: disable, got: %s", cfg.SSLMode)
+	}
+
+	os.Unsetenv("DATABASE_URL")
 }
 
 func TestHTTPPort(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestLoad(t *testing.T) {
 	os.Setenv("PREST_CONF", "testdata/prest.toml")
+	defer os.Unsetenv("PREST_CONF")
 
 	Load()
 	if len(PrestConf.AccessConf.Tables) < 2 {
@@ -18,105 +19,101 @@ func TestLoad(t *testing.T) {
 	if !PrestConf.AccessConf.Restrict {
 		t.Error("expected true, but got false")
 	}
+
 }
 
 func TestParse(t *testing.T) {
 	os.Setenv("PREST_CONF", "testdata/prest.toml")
+
 	viperCfg()
 	cfg := &Prest{}
 	err := Parse(cfg)
 	if err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-
 	if cfg.HTTPPort != 6000 {
 		t.Errorf("expected port: 6000, got: %d", cfg.HTTPPort)
 	}
-
 	if cfg.PGDatabase != "prest" {
 		t.Errorf("expected database: prest, got: %s", cfg.PGDatabase)
 	}
 
 	os.Setenv("PREST_CONF", "../prest.toml")
 	os.Setenv("PREST_HTTP_PORT", "4000")
+
 	viperCfg()
 	cfg = &Prest{}
 	err = Parse(cfg)
-
 	if err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-
 	if cfg.HTTPPort != 4000 {
 		t.Errorf("expected port: 4000, got: %d", cfg.HTTPPort)
 	}
-
 	if !cfg.EnableDefaultJWT {
-		t.Error("expected true but got false")
+		t.Error("EnableDefaultJWT: expected true but got false")
 	}
 
 	os.Setenv("PREST_CONF", "")
-	os.Setenv("PREST_HTTP_PORT", "4000")
 	os.Setenv("PREST_JWT_DEFAULT", "false")
+
 	viperCfg()
 	cfg = &Prest{}
 	err = Parse(cfg)
-
 	if err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-
 	if cfg.HTTPPort != 4000 {
 		t.Errorf("expected port: 4000, got: %d", cfg.HTTPPort)
 	}
-
 	if cfg.EnableDefaultJWT {
-		t.Error("expected false but got true")
+		t.Error("EnableDefaultJWT: expected false but got true")
 	}
 
-	os.Setenv("PREST_HTTP_PORT", "4000")
+	os.Unsetenv("PREST_JWT_DEFAULT")
 	os.Setenv("PREST_CONF", "testdata/prest.toml")
+
 	viperCfg()
 	cfg = &Prest{}
 	err = Parse(cfg)
-
 	if err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-
 	if cfg.HTTPPort != 4000 {
 		t.Errorf("expected port: 4000, got: %d", cfg.HTTPPort)
 	}
 
+	os.Unsetenv("PREST_CONF")
+	os.Unsetenv("PREST_HTTP_PORT")
 	os.Setenv("PREST_JWT_KEY", "s3cr3t")
+
 	viperCfg()
 	cfg = &Prest{}
 	err = Parse(cfg)
-
 	if err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-
 	if cfg.JWTKey != "s3cr3t" {
 		t.Errorf("expected jwt key: s3cr3t, got: %s", cfg.JWTKey)
 	}
-
 	if cfg.JWTAlgo != "HS256" {
 		t.Errorf("expected (default) jwt algo: HS256, got: %s", cfg.JWTAlgo)
 	}
 
+	os.Unsetenv("PREST_JWT_KEY")
 	os.Setenv("PREST_JWT_ALGO", "HS512")
+
 	viperCfg()
 	cfg = &Prest{}
 	err = Parse(cfg)
-
 	if err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-
 	if cfg.JWTAlgo != "HS512" {
 		t.Errorf("expected jwt algo: HS512, got: %s", cfg.JWTAlgo)
 	}
+
+	os.Unsetenv("PREST_JWT_ALGO")
 }
 
 func TestGetDefaultPrestConf(t *testing.T) {
@@ -194,8 +191,8 @@ func TestDatabaseURL(t *testing.T) {
 }
 
 func TestHTTPPort(t *testing.T) {
-	os.Setenv("PREST_CONF", "")
 	os.Setenv("PORT", "8080")
+
 	viperCfg()
 	cfg := &Prest{}
 	err := Parse(cfg)
@@ -208,18 +205,19 @@ func TestHTTPPort(t *testing.T) {
 
 	// set env PREST_HTTP_PORT and PORT
 	os.Setenv("PREST_HTTP_PORT", "3000")
+
 	cfg = &Prest{}
 	err = Parse(cfg)
 	if err != nil {
 		t.Errorf("expected no errors, but got %v", err)
 	}
-
 	if cfg.HTTPPort != 8080 {
 		t.Errorf("expected http port: 8080, got: %d", cfg.HTTPPort)
 	}
 
 	// unset env PORT and set PREST_HTTP_PORT
 	os.Unsetenv("PORT")
+
 	cfg = &Prest{}
 	err = Parse(cfg)
 	if err != nil {
@@ -228,6 +226,8 @@ func TestHTTPPort(t *testing.T) {
 	if cfg.HTTPPort != 3000 {
 		t.Errorf("expected http port: 3000, got: %d", cfg.HTTPPort)
 	}
+
+	os.Unsetenv("PREST_HTTP_PORT")
 }
 
 func Test_parseDatabaseURL(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -217,3 +217,25 @@ func TestHTTPPort(t *testing.T) {
 		t.Errorf("expected http port: 3000, got: %d", cfg.HTTPPort)
 	}
 }
+
+func Test_parseDatabaseURL(t *testing.T) {
+	c := &Prest{PGURL: "postgresql://user:pass@localhost:5432/mydatabase/?sslmode=require"}
+	if err := parseDatabaseURL(c); err != nil {
+		t.Errorf("expected no errors, but got %v", err)
+	}
+	if c.PGDatabase != "mydatabase" {
+		t.Errorf("expected database name: mydatabase, got: %s", c.PGDatabase)
+	}
+	if c.PGPort != 5432 {
+		t.Errorf("expected database port: 5432, got: %d", c.PGPort)
+	}
+	if c.PGUser != "user" {
+		t.Errorf("expected database user: user, got: %s", c.PGUser)
+	}
+	if c.PGPass != "pass" {
+		t.Errorf("expected database password: password, got: %s", c.PGPass)
+	}
+	if c.SSLMode != "require" {
+		t.Errorf("expected database SSL mode: require, got: %s", c.SSLMode)
+	}
+}


### PR DESCRIPTION
Fixes prest/prest#349

As I said on the issue It looks like that the tests were indicating the wrong expected output, so I ran them individually twice to guarantee that they were really failing when they shoudnt and again after changes (`go test -run <test_name>$`)

I know that the changes doesnt look like It does much, but here's the pRest Conf before and after the changes:

### Before
```go
{
    HTTPHost:0.0.0.0 
    HTTPPort:3000 
    PGHost:wwww.compute-1.amazonaws.com 
    PGPort:5432 
    PGUser: 
    PGPass: 
    PGDatabase: 
    PGURL:postgres://xxxx:yyyy@wwww.compute-1.amazonaws.com:5432/qqqq?sslmode=require 
    ContextPath: 
    SSLMode:disable 
    SSLCert: 
    SSLKey: 
    SSLRootCert: 
    PGMaxIdleConn:0 
    PGMAxOpenConn:0 
    PGConnTimeout:0 
    JWTKey:zzzz 
    JWTAlgo: 
    MigrationsPath:./migrations 
    QueriesPath:./queries 
    AccessConf:{
        Restrict:false 
        Tables:[]
        } 
    CORSAllowOrigin:[] 
    CORSAllowHeaders:[] 
    Debug:true 
    Adapter:<nil> 
    EnableDefaultJWT:false 
    EnableCache:true 
    HTTPSMode:false 
    HTTPSCert: 
    HTTPSKey:
}
```

### After

```go
{
    HTTPHost:0.0.0.0 
    HTTPPort:3000 
    PGHost:wwww.compute-1.amazonaws.com 
    PGPort:5432 
    PGUser:xxxx 
    PGPass:yyyy 
    PGDatabase:qqqq 
    PGURL:postgres://xxxx:yyyy@wwww.compute-1.amazonaws.com:5432/qqqq?sslmode=require 
    ContextPath:/ 
    SSLMode:require 
    SSLCert: 
    SSLKey: 
    SSLRootCert: 
    PGMaxIdleConn:10 
    PGMAxOpenConn:10 
    PGConnTimeout:10 
    JWTKey:zzzzz 
    JWTAlgo:HS256 
    MigrationsPath:./migrations 
    QueriesPath:./queries 
    AccessConf:{
        Restrict:false 
        Tables:[]
        } 
    CORSAllowOrigin:[] 
    CORSAllowHeaders:[*] 
    Debug:true 
    Adapter:<nil> 
    EnableDefaultJWT:false 
    EnableCache:true 
    HTTPSMode:false 
    HTTPSCert:/etc/certs/cert.crt 
    HTTPSKey:/etc/certs/cert.key
}
```

### API logs before/after

```go
➜  someapi git:(master) DATABASE_URL=postgres://xxxx:yyyy@wwww.compute-1.amazonaws.com:5432/qqqq?sslmode=require go run main.go
2019/04/08 09:27:43 [warning] Debug ON
2019/04/08 09:27:43 [error] Queries directory  is not created2019/04/08 09:27:43 [msg] &{HTTPHost:0.0.0.0 HTTPPort:3000 PGHost:wwww.compute-1.amazonaws.com PGPort:5432 PGUser: PGPass: PGDatabase: PGURL:postgres://xxxx:yyyy@wwww.compute-1.amazonaws.com:5432/qqqq?sslmode=require ContextPath: SSLMode:disable SSLCert: SSLKey: SSLRootCert: PGMaxIdleConn:0 PGMAxOpenConn:0 PGConnTimeout:0 JWTKey:zzzz JWTAlgo: MigrationsPath:./migrations QueriesPath:./queries AccessConf:{Restrict:false Tables:[]} CORSAllowOrigin:[] CORSAllowHeaders:[] Debug:true Adapter:<nil> EnableDefaultJWT:false EnableCache:true HTTPSMode:false HTTPSCert: HTTPSKey:}


2019/04/08 09:27:43 [error] pq: no pg_hba.conf entry for host "186.228.131.90", user "dbname=", database "dbname=", SSL off
exit status 255

➜  someapi git:(master) DATABASE_URL=postgres://xxxx:yyyy@wwww.compute-1.amazonaws.com:5432/qqqq?sslmode=require go run main.go
2019/04/08 10:09:48 [warning] Debug ON
2019/04/08 10:09:48 [msg] &{HTTPHost:0.0.0.0 HTTPPort:3000 PGHost:wwww.compute-1.amazonaws.com PGPort:5432 PGUser:xxxx PGPass:yyyy PGDatabase:qqqq PGURL:postgres://xxxx:yyyy@wwww.compute-1.amazonaws.com:5432/qqqq?sslmode=require ContextPath:/ SSLMode:require SSLCert: SSLKey: SSLRootCert: PGMaxIdleConn:10 PGMAxOpenConn:10 PGConnTimeout:10 JWTKey:zzzz JWTAlgo:HS256 MigrationsPath:./migrations QueriesPath:./queries AccessConf:{Restrict:false Tables:[]} CORSAllowOrigin:[] CORSAllowHeaders:[*] Debug:true Adapter:<nil> EnableDefaultJWT:false EnableCache:true HTTPSMode:false HTTPSCert:/etc/certs/cert.crt HTTPSKey:/etc/certs/cert.key}


[negroni] listening on 127.0.0.1:9000

```